### PR TITLE
css修正

### DIFF
--- a/sns-app-nuxt/assets/css/message.css
+++ b/sns-app-nuxt/assets/css/message.css
@@ -63,3 +63,9 @@
     margin-left: 60px;
     flex-shrink: 0;
 }
+
+@media screen and (max-width: 959px) {
+    .message__detail-button {
+        margin-left: 48px;
+    }
+}

--- a/sns-app-nuxt/assets/css/message_detail.css
+++ b/sns-app-nuxt/assets/css/message_detail.css
@@ -6,7 +6,7 @@
 
 .comment-group {
     width: 100%;
-    height: calc(100vh - 330px);
+    height: calc(100vh - 374px);
     overflow-y: scroll;
     scrollbar-width: thin;
     scrollbar-color: #888 #f1f1f1;
@@ -49,5 +49,9 @@
 
     .comment-form {
         width: calc(100% - 220px);
+    }
+
+    .comment-group {
+        height: calc(100vh - 390px);
     }
 }


### PR DESCRIPTION
メッセージ詳細画面のコメント表示欄が、コメント送信フォームとかぶって見えなくなっていたため高さを調整
メッセージ削除ボタンの余白を調整