### PR TITLE
コメント入力保持

### DIFF
--- a/sns-app-laravel/src/app/Http/Controllers/CommentController.php
+++ b/sns-app-laravel/src/app/Http/Controllers/CommentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 use App\Models\Post;
 use App\Models\Comment;
 use App\Events\CommentSent;
@@ -70,6 +71,16 @@ class CommentController extends Controller
             $user = auth()->user();
             if (!$user) {
                 return response()->json(['error' => 'Unauthorized'], 401);
+            }
+
+            $validator = Validator::make($request->all(), [
+                'comment' => 'required|string|max:120',
+            ]);
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'error' => 'コメント送信中にエラーが発生しました。',
+                ], 422);
             }
 
             $comment = Comment::create([

--- a/sns-app-laravel/src/app/Http/Controllers/PostController.php
+++ b/sns-app-laravel/src/app/Http/Controllers/PostController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 use App\Models\User;
 use App\Models\Post;
 use App\Services\FirebaseService;
@@ -26,6 +27,16 @@ class PostController extends Controller
             $user = auth()->user();
             if (!$user) {
                 return response()->json(['error' => 'Unauthorized'], 401);
+            }
+
+            $validator = Validator::make($request->all(), [
+                'comment' => 'required|string|max:120',
+            ]);
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'error' => 'コメント送信中にエラーが発生しました。',
+                ], 422);
             }
 
             $post = $user->posts()->create([

--- a/sns-app-laravel/src/routes/api.php
+++ b/sns-app-laravel/src/routes/api.php
@@ -24,9 +24,9 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 Route::middleware(['firebase.auth'])->group(function () {
     Route::get('/v1/posts', [PostController::class, 'index']);
     Route::post('/v1/posts', [PostController::class, 'store']);
+    Route::delete('/v1/posts/{id}', [PostController::class, 'destroy']);
 
     Route::post('/v1/posts/{id}/like', [LikeController::class, 'toggleFavorite']);
-    Route::delete('/v1/posts/{id}', [PostController::class, 'destroy']);
 
     Route::get('/v1/posts/{id}/comments', [CommentController::class, 'index']);
     Route::post('/v1/posts/{id}/comments', [CommentController::class, 'store']);

--- a/sns-app-nuxt/components/SideNav.vue
+++ b/sns-app-nuxt/components/SideNav.vue
@@ -55,10 +55,13 @@ const router = useRouter()
 const { logout } = useAuth()
 
 const validationSchema = yup.object({
-    content: yup.string().required('投稿メッセージは必須です').max(120, '投稿メッセージは120文字以内で入力してください'),
+    content: yup
+        .string()
+        .required('投稿メッセージは必須です')
+        .max(120, '投稿メッセージは120文字以内で入力してください'),
 })
 
-const { resetForm } = useForm({
+const { handleSubmit, validate, resetForm } = useForm({
     validationSchema,
     validateOnMount: false
 })
@@ -77,7 +80,10 @@ const handleLogout = async () => {
 
 const sendMessage = () => {
     run(async () => {
-        if (!content.value.trim()) return;
+        const result = await validate()
+        if (!result.valid) {
+            return // バリデーションエラーがある場合は送信中止
+        }
 
         const auth = getAuth()
         const currentUser = auth.currentUser

--- a/sns-app-nuxt/pages/posts/[id].vue
+++ b/sns-app-nuxt/pages/posts/[id].vue
@@ -39,6 +39,9 @@ import * as yup from 'yup'
 import { useSingleClick } from '~/composables/useSingleClick'
 import Echo from 'laravel-echo';
 import Pusher from 'pusher-js';
+import { useLoadingStore } from '~/stores/useLoadingStore'
+import { useCommentFormStore } from '~/stores/commentFormStore'
+
 
 const config = useRuntimeConfig()
 let channel = null
@@ -51,22 +54,37 @@ const id = route.params.id
 
 const router = useRouter()
 
+const loadingStore = useLoadingStore()
+
 const posts = ref([])
 const comments = ref([])
 
+const commentFormStore = useCommentFormStore()
+
 const validationSchema = yup.object({
-    comment: yup.string().required('コメントは必須です').max(120, 'コメントは120文字以内で入力してください'),
+    comment: yup
+        .string()
+        .required('コメントは必須です')
+        .max(120, 'コメントは120文字以内で入力してください'),
 })
 
-const { resetForm } = useForm({
+const { handleSubmit, validate, resetForm } = useForm({
     validationSchema,
     validateOnMount: false
 })
 
-const { value: comment } = useField('comment')
+//const { value: comment } = useField('comment')
+const { value: comment } = useField('comment', undefined, {
+    validateOnMount: false,
+})
 
 onMounted(() => {
     const auth = getAuth()
+    const savedComment = commentFormStore.getContent(id)
+    if (savedComment) {
+        comment.value = savedComment
+    }
+    //comment.value = commentFormStore.getContent(id)
     onAuthStateChanged(auth, async (user) => {
         if (!user) {
             await router.push('/login')
@@ -114,17 +132,27 @@ onBeforeUnmount(() => {
 
 const fetchMessages = async () => {
     try {
+        loadingStore.setLoading(true)
         const { data } = await $axios.get(`/posts/${id}/comments`)
         posts.value = data.posts
         comments.value = data.comments
     } catch (error) {
         console.error('メッセージ取得失敗', error)
+    } finally {
+        loadingStore.setLoading(false) // ← ここでローディング終了
     }
 }
 
+watch(comment, (newVal) => {
+    commentFormStore.setContent(id, newVal)
+})
+
 const sendComment = () => {
     run(async () => {
-        if (!comment.value.trim()) return;
+        const result = await validate()
+        if (!result.valid) {
+            return // バリデーションエラーがある場合は送信中止
+        }
 
         const auth = getAuth()
         const currentUser = auth.currentUser
@@ -140,6 +168,7 @@ const sendComment = () => {
             })
             //comments.value.push(res.data.comment)
             resetForm()
+            commentFormStore.setContent(id, '')
 
         } catch (error) {
             console.error('送信に失敗しました', error)

--- a/sns-app-nuxt/stores/commentFormStore.ts
+++ b/sns-app-nuxt/stores/commentFormStore.ts
@@ -1,0 +1,15 @@
+import { defineStore } from 'pinia'
+
+export const useCommentFormStore = defineStore('commentForm', {
+    state: () => ({
+        contents: {} as Record<string, string>
+    }),
+    actions: {
+        setContent(postId: string, text: string) {
+        this.contents[postId] = text
+        },
+        getContent(postId: string): string {
+        return this.contents[postId] || ''
+        }
+    }
+})


### PR DESCRIPTION
各コメント詳細画面でコメント入力を保持

投稿メッセージ、コメント送信時にバリデーションエラーが表示されている状態でも送信され、保存される状態だったため、フロントエンドでは送信されないように、バックエンドではエラー画面に遷移するよう制御